### PR TITLE
Patch for a vulnerability with the surface tool according to #80

### DIFF
--- a/SyncAPI/Children/SyncModule.luau
+++ b/SyncAPI/Children/SyncModule.luau
@@ -456,9 +456,6 @@ function SyncModule.ConvertPartToType(Part, Type, Params)
 		return Part
 	end
 
-	-- Get the common properties through both classes
-	local CommonProperties = SyncModule.PropScan.GetCommonPropertiesFromClasses(CurrentType, Type)
-
 	local NewPart
 	local FutureSize
 	local SpecialMeshToRestore
@@ -1641,12 +1638,34 @@ local Actions = {
 			end;
 		end;
 
+		-- Enumerate every possible surface property
+		local NameToSurface = {
+			Right = "RightSurface",
+			Top = "TopSurface",
+			Back = "BackSurface",
+			Left = "LeftSurface",
+			Bottom = "BottomSurface",
+			Front = "FrontSurface",
+		}
+
 		-- Perform each change
 		for Part, Change in pairs(ChangeSet) do
 
 			-- Apply each surface change
 			for Surface, SurfaceType in pairs(Change.Surfaces) do
-				Part[Surface .. 'Surface'] = SurfaceType;
+				-- Get the surface's name (if it exists)
+				local SurfaceName = NameToSurface[Surface]
+
+				-- Make sure it exists
+				assert(SurfaceName, "[FORK3X]: An invalid surface name was submitted. Aborting.")
+
+				-- Also check the surface type
+				assert(typeof(SurfaceType) == "EnumItem" 
+					and SurfaceType.EnumType == Enum.SurfaceType,
+					"[FORK3X]: An invalid surface type has been submitted. Aborting.")
+
+				-- If everything is correct, set the new surface type
+				Part[SurfaceName] = SurfaceType;
 			end;
 
 		end;


### PR DESCRIPTION
## The problem

To paraphrase the main issue:

When concatenating strings (so assemble them), you can use "\0" to prevent the concatenation from happening.

This means that if I do `"Hello\0" .. " there!"`, the result should be "Hello" and not "Hello there!"

The issue with this is that the surface tool uses this to find the property according to the side as shown here:
```luau
Part[Surface .. 'Surface'] = SurfaceType;
```
This means that if one fires the SyncAPI with "Parent\0" as `Surface`, and `game.StarterPack` as `SurfaceType`, this would be equivalent to:
```luau
Part.Parent = game.StarterPack
```
Since the "\0" cancelled the concatenation with "Surface". This allows exploiters to pretty much choose any property they want, and so use Fork3X to have full control over the game and have destructive behaviours, including:

- Bypassing throttling to edit multiple properties at once
- Edit properties Fork3X shouldn't be able to edit

This explains why a patch to this must be pulled as quickly as possible.

## The fix

The PR simply changes the following (along removing an useless variable):

- The name of the surface goes through a dictionary to get the correct property's name. Anything that's not a surface will get blocked via asserting.
- The property is also asserted, and must be an EnumItem that belongs to Enum.SurfaceType

This completely removes concatenation from the method, making this trick useless and ensuring safety in-game.

*Originally reported by @Bloxaar in #80*