### PR TITLE
Make it not freeze settings from Options module (respects FreezeSettings option)

### DIFF
--- a/Fork3X/Options.luau
+++ b/Fork3X/Options.luau
@@ -910,4 +910,4 @@ end
 
 Settings.VariableSettings = {}
 
-return table.freeze(Settings)
+return if Settings.FreezeTable then table.freeze(Settings) else Settings

--- a/Fork3X/Options.luau
+++ b/Fork3X/Options.luau
@@ -910,4 +910,4 @@ end
 
 Settings.VariableSettings = {}
 
-return if Settings.FreezeTable then table.freeze(Settings) else Settings
+return if Settings.FreezeSettings then table.freeze(Settings) else Settings


### PR DESCRIPTION
because on serverside i have the ability to require options module before parenting it to players backpack and i can freeze it before other scripts intercept it