### PR TITLE
remove unnecessary second auto update check

### DIFF
--- a/Fork3X/Addons/AutoUpdating.luau
+++ b/Fork3X/Addons/AutoUpdating.luau
@@ -107,13 +107,6 @@ local Addon = {
 					NewTool = NewTool:FindFirstChildOfClass("Tool")
 					-- Prevent update attempt loops since fetched version is now cached
 					--NewTool.AutoUpdate.Value = false;
-					
-					-- Cancel replacing current tool if fetched version is the same
-					if NewTool.Version.Value == Tool.Version.Value then
-						OriginalValue(SyncModule)
-						
-						return;
-					end;
 
 					-- Detach update script from tool and save old tool parent
 					script.Parent = nil;

--- a/Fork3X/Addons/AutoUpdating.luau
+++ b/Fork3X/Addons/AutoUpdating.luau
@@ -107,6 +107,17 @@ local Addon = {
 					NewTool = NewTool:FindFirstChildOfClass("Tool")
 					-- Prevent update attempt loops since fetched version is now cached
 					--NewTool.AutoUpdate.Value = false;
+					
+					-- Cancel replacing current tool if fetched version is the same
+					if NewTool.Version.Value == Tool.Version.Value then
+						
+						DescendantCount.Value = 0
+						DescendantCounter.Enabled = true
+					
+						OriginalValue(SyncModule)
+											
+						return;
+					end;
 
 					-- Detach update script from tool and save old tool parent
 					script.Parent = nil;


### PR DESCRIPTION
this confused me and made me thing that f3x is broken in starterpack (it wasn't i just commented out the first check and forgot to comment out the second one)

anyway this second check is not needed because you already have the first check before that one its basically same thing idk correct me if im wrong